### PR TITLE
Article source gives 404 error

### DIFF
--- a/scroll.settings
+++ b/scroll.settings
@@ -1,6 +1,6 @@
 title JTree
 description Build your own language using Tree Notation.
-github https://github.com/publicdomaincompany/jtree
-git https://github.com/publicdomaincompany/jtree
+github https://github.com/breck7/jtree
+git https://github.com/breck7/jtree
 twitter https://twitter.com/treenotation
 email jtree@treenotation.org


### PR DESCRIPTION
Hi Breck (@breck7),

The main [publicdomaincompany](https://github.com/publicdomaincompany/jtree/) JTree URL [redirects](https://wheregoes.com/trace/20223465510/) without any problem. However, the [Article Source](https://github.com/publicdomaincompany/jtree/readme.scroll) link [fails to redirect](https://wheregoes.com/trace/20223459852/) and is generating a 404 error.

I have updated the link to https://github.com/breck7/jtree

Kind Regards,
Liam