### PR TITLE
Correct error in #144

### DIFF
--- a/scroll.settings
+++ b/scroll.settings
@@ -1,6 +1,6 @@
 title JTree
 description Build your own language using Tree Notation.
 github https://github.com/breck7/jtree
-git https://github.com/breck7/jtree
+git https://github.com/breck7/jtree/blob/main/
 twitter https://twitter.com/treenotation
 email jtree@treenotation.org


### PR DESCRIPTION
Hi Breck (@breck7),

I messed up. 

In #144, I changed both the "github" and the "git" settings to be the same value. The "Article Source" links on the following pages are now broken:

- https://jtree.treenotation.org/languageChecklist.html
- https://jtree.treenotation.org/index.html
- https://jtree.treenotation.org/releaseNotes.html


I have added the "/blob/main/" to the "git" link as in the BreckYunits.com [scroll.settings](https://github.com/breck7/breckyunits.com/blob/6f3ffc12d3032a0245ed4e68088bbd41c98ca074/scroll.settings#L5), for example. Trusting that this PR corrects my mistake.

Kind Regards,
Liam